### PR TITLE
Fix orin nano patch

### DIFF
--- a/patches_orin_nano/patches/5.1.1_nano_imx708_v0.1.0.patch
+++ b/patches_orin_nano/patches/5.1.1_nano_imx708_v0.1.0.patch
@@ -407,7 +407,7 @@ index 000000000..6b864e9f7
 +		i2c_0:i2c@0 {
 +			imx708_cam0: rpicam3_imx708_a@1a {
 +				status = "okay";
-+				compatible = "sony,imx708";
++				compatible = "ridgerun,imx708";
 +				reg = <0x1a>;
 +				devnode = "video0";
 +				physical_w = "3.680";
@@ -610,7 +610,7 @@ index 01f41c8d0..a3644b868 100644
  				};
  			};
 +
-+			rbpcv3_imx708_a@1a {
++			rpicam3_imx708_a@1a {
 +				mode0 {
 +					tegra_sinterface = "serial_b";
 +					lane_polarity = "6";
@@ -1002,7 +1002,7 @@ index 000000000..c33fc24b5
 +#include "imx708_mode_tbls.h"
 +
 +static const struct of_device_id imx708_of_match[] = {
-+	{.compatible = "sony,imx708",},
++	{.compatible = "ridgerun,imx708",},
 +	{},
 +};
 +


### PR DESCRIPTION
Currently we have only tested orin nano, the patch of jetson nano has not been tested yet.

The specific problem is described as follows:
In the device tree, imx708_cam0, imx708_cam1 use different compatibles. The driver uses "sony,imx708". I think you want to use "ridgerun,imx708", so I unified the compatibles in the device tree and driver into "ridgerun,imx708".

In addition, the node name of imx708 in tegra234-p3768-0000-a0.dtsi does not match the one in other files and has also been modified.